### PR TITLE
Rewrite ios screens for ios 26

### DIFF
--- a/AddDebtView.swift
+++ b/AddDebtView.swift
@@ -1,7 +1,7 @@
 import SwiftUI
 
 struct AddDebtView: View {
-    @Environment(\.presentationMode) var presentationMode
+    @Environment(\.dismiss) var dismiss
     @EnvironmentObject var debtStore: DebtStore
     @EnvironmentObject var themeManager: ThemeManager
     
@@ -20,7 +20,7 @@ struct AddDebtView: View {
     @State private var keyboardHeight: CGFloat = 0
     
     var body: some View {
-        NavigationView {
+        NavigationStack {
             GeometryReader { geometry in
                 ZStack {
                     themeManager.backgroundColor.ignoresSafeArea()
@@ -31,7 +31,7 @@ struct AddDebtView: View {
                             HStack {
                                 Button("Отмена") {
                                     hideKeyboard()
-                                    presentationMode.wrappedValue.dismiss()
+                                    dismiss()
                                 }
                                 .foregroundColor(themeManager.secondaryTextColor)
                                 
@@ -301,7 +301,7 @@ struct AddDebtView: View {
         )
         
         debtStore.addDebt(newDebt)
-        presentationMode.wrappedValue.dismiss()
+        dismiss()
     }
 }
 

--- a/ContentView.swift
+++ b/ContentView.swift
@@ -6,6 +6,7 @@ struct ContentView: View {
     @State private var selectedTab = 0
     
     var body: some View {
+        NavigationStack {
         ZStack {
             themeManager.backgroundColor.ignoresSafeArea()
             
@@ -84,6 +85,7 @@ struct ContentView: View {
                     alignment: .top
                 )
             }
+        }
         }
     }
 }
@@ -189,6 +191,8 @@ struct SettingsView: View {
         .sheet(isPresented: $showingNotificationSettings) {
             NotificationSettingsView()
                 .environmentObject(themeManager)
+                .presentationDetents([.medium, .large])
+                .presentationDragIndicator(.visible)
         }
     }
 }

--- a/DebtDetailView.swift
+++ b/DebtDetailView.swift
@@ -4,7 +4,7 @@ struct DebtDetailView: View {
     let debt: Debt
     @EnvironmentObject var debtStore: DebtStore
     @EnvironmentObject var themeManager: ThemeManager
-    @Environment(\.presentationMode) var presentationMode
+    @Environment(\.dismiss) var dismiss
     @State private var showingEditDebt = false
     @State private var showingDeleteAlert = false
     @State private var showingStatusChangeAlert = false
@@ -61,7 +61,7 @@ struct DebtDetailView: View {
             Button("Отмена", role: .cancel) { }
             Button("Удалить", role: .destructive) {
                 debtStore.deleteDebt(currentDebt)
-                presentationMode.wrappedValue.dismiss()
+                dismiss()
             }
         } message: {
             Text("Вы уверены, что хотите удалить долг от \(currentDebt.debtorName) на сумму \(currentDebt.formattedAmount)?")
@@ -111,7 +111,7 @@ struct DebtDetailView: View {
         VStack(spacing: 16) {
             HStack {
                 Button(action: {
-                    presentationMode.wrappedValue.dismiss()
+                    dismiss()
                 }) {
                     Image(systemName: "chevron.left")
                         .foregroundColor(themeManager.primaryTextColor)

--- a/DebtListView.swift
+++ b/DebtListView.swift
@@ -47,20 +47,22 @@ struct DebtListView: View {
     }
     
     var body: some View {
-        NavigationView {
-            ZStack {
-                themeManager.backgroundColor.ignoresSafeArea()
-                mainContentView
-            }
-            .navigationBarHidden(true)
+        ZStack {
+            themeManager.backgroundColor.ignoresSafeArea()
+            mainContentView
         }
+        .toolbar(.hidden, for: .navigationBar)
         .sheet(isPresented: $showingAddDebt) {
             AddDebtView()
                 .environmentObject(themeManager)
+                .presentationDetents([.medium, .large])
+                .presentationDragIndicator(.visible)
         }
         .sheet(isPresented: $showingNotificationSettings) {
             NotificationSettingsView()
                 .environmentObject(themeManager)
+                .presentationDetents([.medium, .large])
+                .presentationDragIndicator(.visible)
         }
         .onAppear { updateVisibleDebts() }
         .onChange(of: selectedFilter) { updateVisibleDebts() }

--- a/EditDebtView.swift
+++ b/EditDebtView.swift
@@ -1,7 +1,7 @@
 import SwiftUI
 
 struct EditDebtView: View {
-    @Environment(\.presentationMode) var presentationMode
+    @Environment(\.dismiss) var dismiss
     @EnvironmentObject var debtStore: DebtStore
     @EnvironmentObject var themeManager: ThemeManager
     
@@ -35,7 +35,7 @@ struct EditDebtView: View {
     }
     
     var body: some View {
-        NavigationView {
+        NavigationStack {
             GeometryReader { geometry in
                 ZStack {
                     themeManager.backgroundColor.ignoresSafeArea()
@@ -46,7 +46,7 @@ struct EditDebtView: View {
                             HStack {
                                 Button("Отмена") {
                                     hideKeyboard()
-                                    presentationMode.wrappedValue.dismiss()
+                                    dismiss()
                                 }
                                 .foregroundColor(themeManager.secondaryTextColor)
                                 
@@ -318,7 +318,7 @@ struct EditDebtView: View {
         updatedDebt.interestRate = interestRateValue
         
         debtStore.updateDebt(updatedDebt)
-        presentationMode.wrappedValue.dismiss()
+        dismiss()
     }
 }
 


### PR DESCRIPTION
Migrate SwiftUI navigation and presentation APIs to iOS 16+ standards to modernize the app while retaining custom UI/UX.

---
<a href="https://cursor.com/background-agent?bcId=bc-4741def1-f309-4109-9e00-284d26d0bc4c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-4741def1-f309-4109-9e00-284d26d0bc4c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

